### PR TITLE
feat: make NAT gateways optional and VPC endpoint services configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module "vpc" {
   logging_key_id = module.logging.kms_key_arn
 
   private_subnets = ["10.0.22.0/26", "10.0.22.64/26", "10.0.22.128/26"]
-  public_subnets  = ["10.0.20.0/26", "10.0.20.64/26", "10.0.20.128/26"]
+  public_subnets = ["10.0.20.0/26", "10.0.20.64/26", "10.0.20.128/26"]
 }
 ```
 
@@ -71,22 +71,26 @@ peers = {
 | log_retention_period | Retention period for flow logs, in days.                                                                    | `string` | 30      | no       |
 | environment          | Environment for the project.                                                                                | `string` | `"dev"` | no       |
 | peers                | List of VPC peering connections.                                                                            | `map`    | `{}`    | no       |
+| enable_nat_gateway   | Whether to include any NAT gateways.                                                                        | `bool`   | `true`  | no       |
 | single_nat_gateway   | Create a single NAT gateway, rather than 1 in each private subnet. **_Cheaper, but not highly available._** | `bool`   | `false` | no       |
 | tags                 | Optional tags to be applied to all resources.                                                               | `list`   | `[]`    | no       |
 
 ## Outputs
 
-| Name                        | Description                             | Type     |
-|-----------------------------|-----------------------------------------|----------|
+| Name                        | Description                                                  | Type     |
+|-----------------------------|--------------------------------------------------------------|----------|
 | availability_zones          | The availability zones in which the VPC subnets are created. | `list`   |
-| peer_ids                    | The IDs of any created VPC peering connections. | `list`   |
-| private_subnets             | The IDs of the private subnets in the VPC.             | `list`   |
+| peer_ids                    | The IDs of any created VPC peering connections.              | `list`   |
+| private_subnets             | The IDs of the private subnets in the VPC.                   | `list`   |
 | private_subnets_cidr_blocks | The CIDR blocks of the private subnets in the VPC.           | `list`   |
-| public_subnets              | The IDs of the public subnets in the VPC.               | `list`   |
+| public_subnets              | The IDs of the public subnets in the VPC.                    | `list`   |
 | public_subnets_cidr_blocks  | The CIDR blocks of the public subnets in the VPC.            | `list`   |
-| vpc_id                      | The ID of the VPC.                  | `string` |
+| vpc_id                      | The ID of the VPC.                                           | `string` |
 
 [badge-checks]: https://github.com/codeforamerica/tofu-modules-aws-vpc/actions/workflows/main.yaml/badge.svg
+
 [badge-release]: https://img.shields.io/github/v/release/codeforamerica/tofu-modules-aws-vpc?logo=github&label=Latest%20Release
+
 [code-checks]: https://github.com/codeforamerica/tofu-modules-aws-vpc/actions/workflows/main.yaml
+
 [latest-release]: https://github.com/codeforamerica/tofu-modules-aws-vpc/releases/latest

--- a/README.md
+++ b/README.md
@@ -61,19 +61,20 @@ peers = {
 
 ## Inputs
 
-| Name                 | Description                                                                                                 | Type     | Default | Required |
-|----------------------|-------------------------------------------------------------------------------------------------------------|----------|---------|----------|
-| cidr                 | IPv4 CIDR block for the VPC.                                                                                | `string` | n/a     | yes      |
-| logging_key_id       | KMS key to use for log encryption.                                                                          | `string` | n/a     | yes      |
-| private_subnets      | List of private subnet CIDR blocks.                                                                         | `list`   | n/a     | yes      |
-| project              | Name of the project.                                                                                        | `string` | n/a     | yes      |
-| public_subnets       | List of public subnet CIDR blocks.                                                                          | `list`   | n/a     | yes      |
-| log_retention_period | Retention period for flow logs, in days.                                                                    | `string` | 30      | no       |
-| environment          | Environment for the project.                                                                                | `string` | `"dev"` | no       |
-| peers                | List of VPC peering connections.                                                                            | `map`    | `{}`    | no       |
-| enable_nat_gateway   | Whether to include any NAT gateways.                                                                        | `bool`   | `true`  | no       |
-| single_nat_gateway   | Create a single NAT gateway, rather than 1 in each private subnet. **_Cheaper, but not highly available._** | `bool`   | `false` | no       |
-| tags                 | Optional tags to be applied to all resources.                                                               | `list`   | `[]`    | no       |
+| Name                        | Description                                                                                                 | Type     | Default                                                                                                              | Required |
+|-----------------------------|-------------------------------------------------------------------------------------------------------------|----------|----------------------------------------------------------------------------------------------------------------------|----------|
+| cidr                        | IPv4 CIDR block for the VPC.                                                                                | `string` | n/a                                                                                                                  | yes      |
+| logging_key_id              | KMS key to use for log encryption.                                                                          | `string` | n/a                                                                                                                  | yes      |
+| private_subnets             | List of private subnet CIDR blocks.                                                                         | `list`   | n/a                                                                                                                  | yes      |
+| project                     | Name of the project.                                                                                        | `string` | n/a                                                                                                                  | yes      |
+| public_subnets              | List of public subnet CIDR blocks.                                                                          | `list`   | n/a                                                                                                                  | yes      |
+| log_retention_period        | Retention period for flow logs, in days.                                                                    | `string` | 30                                                                                                                   | no       |
+| environment                 | Environment for the project.                                                                                | `string` | `"dev"`                                                                                                              | no       |
+| peers                       | List of VPC peering connections.                                                                            | `map`    | `{}`                                                                                                                 | no       |
+| interface_endpoint_services | List of AWS services to create interface VPC endpoints for.                                                 | `list`   | ["ec2", "ec2messages", "ecr.api", "ecr.dkr", "guardduty-data", "ssm", "ssm-contacts", "ssm-incidents","ssmmessages"] | no       |
+| enable_nat_gateway          | Whether to include any NAT gateways.                                                                        | `bool`   | `true`                                                                                                               | no       |
+| single_nat_gateway          | Create a single NAT gateway, rather than 1 in each private subnet. **_Cheaper, but not highly available._** | `bool`   | `false`                                                                                                              | no       |
+| tags                        | Optional tags to be applied to all resources.                                                               | `list`   | `[]`                                                                                                                 | no       |
 
 ## Outputs
 

--- a/local.tf
+++ b/local.tf
@@ -10,17 +10,7 @@ locals {
   )
 
   # Define the set of services that require interface endpoints.
-  interface_endpoint_services = toset([
-    "ec2",
-    "ec2messages",
-    "ecr.api",
-    "ecr.dkr",
-    "guardduty-data",
-    "ssm",
-    "ssm-contacts",
-    "ssm-incidents",
-    "ssmmessages"
-  ])
+  interface_endpoint_services = var.interface_endpoint_services
   interface_endpoints = {
     for service in local.interface_endpoint_services : service => {
       service = service

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ module "vpc" {
   public_subnets      = var.public_subnets
   public_subnet_tags  = { use = "public" }
 
-  enable_nat_gateway   = true
+  enable_nat_gateway   = var.enable_nat_gateway
   single_nat_gateway   = var.single_nat_gateway
   enable_dns_hostnames = true
   enable_dns_support   = true

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,22 @@ variable "peers" {
   default     = {}
 }
 
+variable "interface_endpoint_services" {
+  type        = set(string)
+  description = "AWS services to create interface VPC endpoints for."
+  default = [
+    "ec2",
+    "ec2messages",
+    "ecr.api",
+    "ecr.dkr",
+    "guardduty-data",
+    "ssm",
+    "ssm-contacts",
+    "ssm-incidents",
+    "ssmmessages"
+  ]
+}
+
 variable "private_subnets" {
   type        = list(string)
   description = "List of private subnet CIDR blocks."

--- a/variables.tf
+++ b/variables.tf
@@ -47,6 +47,12 @@ variable "public_subnets" {
   description = "List of public subnet CIDR blocks."
 }
 
+variable "enable_nat_gateway" {
+  type        = bool
+  default     = true
+  description = "Whether to include any NAT gateways."
+}
+
 variable "single_nat_gateway" {
   type        = bool
   default     = false


### PR DESCRIPTION
There are some cases, where we don't need egress to the public internet. Additionally, sometimes we want to add additional items to the list of VPC endpoint services. It would be nice if both of these configurations were configurable.

This PR introduces and uses variables that control the creation of NAT gateways and make the list of VPC endpoints configurable. Both variables default to their current hard coded values.